### PR TITLE
docs: add Hanzilla Jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
 
 [Canadian Tech Internships](https://github.com/jenndryden/Canadian-Tech-Internships-Summer-2024) <sub><sup> Job board for solely Canadian internships. <sup><sub>
 
+[Hanzilla Jobs](https://jobs.hanzilla.co/internships/) <sub><sup> Daily-updated Canadian student and recent-grad jobs board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more. <sup><sub>
+
 [S24 SWE Internships](https://github.com/AlanChen4/Summer-2024-SWE-Internships) <sub><sup> Summer 2024 SWE role job board. <sup><sub>
 
 [Tech/New Grad Positions](https://github.com/Trident-Development/2024-new-grad-intern) <sub><sup> All-season job board for both internships and new grad tech positions. <sup><sub>


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Job Boards section as a current Canada-focused student/recent-grad jobs board.
- Use the internships deep link because this README already lists internship/new-grad resources.

## Why
Hanzilla Jobs is a free daily-updated Canadian student/recent-grad board covering internships, co-ops, new grad, junior, and entry-level roles across tech plus adjacent fields like finance, engineering, business, and sciences.

## Test plan
- Markdown-only change; reviewed README diff locally.
